### PR TITLE
Enabled Logging and Color Control for hi tool output

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ enable_logging = false
 
 ```
 
+#### Colors and Styles ####
+Colors and styles can be applied to various parts of the *hi* display
+output.  The ` config.ini ` file that comes with this tool provides some
+examples.
+
+Read more about the styles and colors that are available for use in ` colors.md `.
+
+
 ### Paths ###
 
 ##### checks_file #####
@@ -156,7 +164,12 @@ Style of the column within a table.
 ##### text_style #####
 Style of the text for status messages (within a column).
 
-Read more about the styles and colors that you can use in ` colors.md `.
+
+### OS Bar ###
+##### os_text_style #####
+Style of the text for the Operating System and End of Life bar.
+This feature currently on supports Ubuntu operating systems at the moment.
+
 
 ### Logging ###
 ##### enable_logging #####

--- a/README.md
+++ b/README.md
@@ -33,23 +33,11 @@ Ensure you have the following installed on your system:
 
 *   Python 3.x (>= 3.6)
     
-*   Required Python modules:
-    
-    *   subprocess
-        
-    *   socket
-        
-    *   re
-        
-    *   os
-        
-    *   pyyaml
-        
-    *   rich
-        
-
 You can check your version of python with the following command:
 `   python3 --version   `
+
+*   Required Python modules:
+See ` requirements.txt `.        
 
 Ensure that your terminal supports the UTF8 character set for proper display of status icons.
 
@@ -61,17 +49,20 @@ Ensure that your terminal supports the UTF8 character set for proper display of 
     
 2.  `pip install -r requirements.txt`
 
-3.  `python3 host_information.py`
+3.  Update ` config/config.ini ` and your custom ` checks.yml ` file
+    accordingly.
+
+4.  `python3 hi/host_information.py`
     
 
-### Configuration
+# Configuration
 There are currently three (3) configuration files that 'hi' depends on.  They are as
 follows:
 - config/config.ini
 - config/groups.yml
 - config/checks.yml
 
-#### config/config.ini ####
+## config/config.ini ####
 This file is the main configuration file that tells 'hi' what files it needs and options it should enable.
 
 For example, you can use the 'checks_file' to specify a custom location of
@@ -80,25 +71,56 @@ the specific checks.yml formatted file you would like to use.
 Also, you can configure table output options to customize how your reports
 displayed.
 
+##### config.ini example #####
+```
+[Paths]
+checks_file = config/checks.yml
+log_file = logs/hi_log.json
+
+[Report]
+header_style = black on yellow
+hostname_style = yellow on black
+ip_style = bold green on black
+
+[Tables]
+number_of_columns = 3 
+default_style = bold magenta
+header_style = bold magenta
+border_style = bold bright_green
+column_style = bright_green on magenta
+text_style = None
+
+[Logging]
+enable_logging = false
+
+```
+
+### Paths ###
+
 ##### checks_file #####
 The 'checks_file' setting tells *hi* where YOUR custom 'checks.yml' file is located.  The checks file can be named anything,
 as long as it is a properly formatted YAML file.  It should look something like the checks.yml or example.yml files that comes
 with this tool.
 
-config.ini example:
+##### log_file #####
+The `log_file` is the location where 'hi' writes it's logging information.
+The logs are in JSONL (JSON Lines) format, and so this file would
+ideally be named with a .json extension.
+
+You can create a sub-directory to store your logs within the 'hi' tool
+directory, for example 'logs/', and have 'hi' write it's logs there.
+
+For example
 ```
 [Paths]
 checks_file = config/checks.yml
-
-[Tables]
-number_of_columns = 2 
-default_style = None
-header_style = bold magenta
-border_style = bright_white
-column_style = white
-text_style = None
-
+log_file = logs/hi_log.json
 ```
+
+The JSONL logging format was selected because it is easily parsable by 
+upstream log analysis and monitoring tools, such as Logstash, Graylog, 
+Zabbix, Splunk, and others.
+
 
 ### Report ###
 ##### header_style #####
@@ -136,6 +158,10 @@ Style of the text for status messages (within a column).
 
 Read more about the styles and colors that you can use in ` colors.md `.
 
+### Logging ###
+##### enable_logging #####
+Set ` enable_logging = true ` if you want to enable logging.  This is set
+to 'false' by default.  If you enable logging, be sure to configure the `log_file` variable under [Paths] as well.
 
 #### config/groups.yml ####
 *hi* "status groups" typically referred to simply as "groups" can be customized in the `  config/groups.yml  ` file, and only those system checks

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,7 +62,7 @@ changes may already be in development progress.
     - API friendly data structures
         - Improve the structure of messages so this data can be exposed in
           an API for use in another view, like an HTML report.
-    - Do something a bit more constructive with the hi header ("Host
+    - [🚧]Do something a bit more constructive with the hi header ("Host
       Information:") line
 
 - Aesthetic Improvements
@@ -83,13 +83,18 @@ changes may already be in development progress.
             - The check command indicators and status messages
             - Maybe some historical info via status change log
 
-    - Check Status Change Log
-        - Log state changes cor status checks
+    - [🚧]Check Status Change Log
+        - Log state changes or status checks
         - This may be a straight log file (JSONL)
             - Log can be controlled by logrotate
 
 #### Testing ####
 - Improved testing scope, focused on indicators and statuses
+- Include testing for logging configuration, number of open files.
+- Include testing for long running watch instances (see if open files stay
+  static or trend upward)
+- Include testing for sub-checks
+- Include testing for state.json
 
 #### Logical Separation of Concerns ####
 - Externalization of hard-coded configs into config/config.ini

--- a/config/config.ini
+++ b/config/config.ini
@@ -15,5 +15,7 @@ border_style = bold bright_green
 column_style = bright_green on magenta
 text_style = None
 
+[OS Bar]
+os_text_style = bright_green on dark_green
 [Logging]
 enable_logging = false

--- a/config/config.ini
+++ b/config/config.ini
@@ -16,6 +16,6 @@ column_style = bright_green on magenta
 text_style = None
 
 [OS Bar]
-os_text_style = bright_green on dark_green
+os_text_style = bright_green on magenta
 [Logging]
 enable_logging = false

--- a/config/config.ini
+++ b/config/config.ini
@@ -1,5 +1,6 @@
 [Paths]
 checks_file = config/checks.yml
+log_file = hi_log.json
 
 [Report]
 header_style = black on yellow
@@ -7,10 +8,12 @@ hostname_style = yellow on black
 ip_style = bold green on black
 
 [Tables]
-number_of_columns = 3
+number_of_columns = 3 
 default_style = bold magenta
 header_style = bold magenta
 border_style = bold bright_green
 column_style = bright_green on magenta
 text_style = None
 
+[Logging]
+enable_logging = false

--- a/hi/check_ubuntu_eol.py
+++ b/hi/check_ubuntu_eol.py
@@ -4,10 +4,24 @@ import requests
 import json
 import os
 import time
+import configparser
+from rich.console import Console
+from rich.text import Text
+from rich.padding import Padding
+
+def get_script_dir():
+    ''' Returns the directory where the script is running from '''
+    return os.path.dirname(os.path.abspath(__file__))
+
+# Read in 'config/config.ini'
+script_dir = get_script_dir()
+config = configparser.ConfigParser()
+config.read(os.path.join(os.path.dirname(script_dir), 'config/config.ini'))
 
 CACHE_FILE = '/tmp/ubuntu_eol_cache.json'
 CACHE_DURATION = 7 * 24 * 60 * 60  # One week in seconds
 OS_INFO = []
+console = Console()
 
 def get_ubuntu_version():
     ''' Retrieves the current Ubuntu version '''
@@ -55,7 +69,15 @@ def calculate_time_until_eol(eol_date):
 
 def main():
     os_name, version = get_ubuntu_version()
+    ini_text_style = None
+    line_style = None
     url = 'https://endoflife.date/api/ubuntu.json'
+
+    try:
+        ini_text_style = config.get('OS Bar', 'os_text_style')
+    except Exception as e:
+        ini_text_style = "bright_green on black"
+    line_style = ini_text_style
 
     try:
         data = get_eol_dates(url)
@@ -69,7 +91,11 @@ def main():
 
         if eol_date:
             years, months, weeks, days = calculate_time_until_eol(eol_date)
-            print(f"Operating System: {os_name} {version} | End of Life: {eol_date} ({years} years, {months} months, {weeks} weeks, and {days} days remaining)")
+            text = Text(f"Operating System: {os_name} {version} | End of Life: {eol_date} ({years} years, {months} months, {weeks} weeks, and {days} days remaining)", style=line_style)
+            terminal_width = console.width
+            padding_width = terminal_width - len(text.plain)
+            padded_text = Padding(text + " " * padding_width, (0,0,0,0), style="on black")
+            console.print(padded_text)
         else:
             print(f"End of Life date not found for {os_name} version {version}.")
     except requests.exceptions.RequestException as e:

--- a/hi/check_ubuntu_eol.py
+++ b/hi/check_ubuntu_eol.py
@@ -7,12 +7,15 @@ import time
 
 CACHE_FILE = '/tmp/ubuntu_eol_cache.json'
 CACHE_DURATION = 7 * 24 * 60 * 60  # One week in seconds
+OS_INFO = []
 
 def get_ubuntu_version():
     ''' Retrieves the current Ubuntu version '''
-    result = subprocess.run(['lsb_release', '-si', '-sr'], stdout=subprocess.PIPE)
-    output = result.stdout.decode('utf-8').strip().split()
-    return output[0], output[1]  # Returns OS name and version
+    global OS_INFO
+    if OS_INFO == []:
+        result = subprocess.run(['lsb_release', '-si', '-sr'], stdout=subprocess.PIPE)
+        OS_INFO = result.stdout.decode('utf-8').strip().split()
+    return OS_INFO[0], OS_INFO[1]  # Returns OS name and version
 
 def fetch_eol_dates(url):
     ''' Fetches the EOL dates data from the endoflife.date API '''

--- a/hi/df_bargraph.py
+++ b/hi/df_bargraph.py
@@ -41,7 +41,13 @@ def format_size(used, total, free):
 
 def get_disk_usage():
     """Gather disk usage information."""
-    partitions = psutil.disk_partitions()
+    partitions = {}
+    try:
+        partitions = psutil.disk_partitions()
+    except OSError as e:
+        if e.errno == 24: # Too many files open
+            print(f"too many files open: %s", e)
+
     usage_list = []
 
     for partition in partitions:

--- a/hi/host_information.py
+++ b/hi/host_information.py
@@ -132,11 +132,6 @@ def compile_output_messages(check, cmd_output, group, info=None, indicators=None
     check_record = {}
     output_messages = []
 
-    # Configure logging at the start of your script
-    log_file_path = 'system_checks.json'
-    configure_logging(log_file_path)
-
-
     # The below 'if output:' statement means that the command completed
     # successfully, and 'output' contains any data returned by the executed
     # command.  'check' contains the name of the check in config/checks.yml.
@@ -451,6 +446,10 @@ def check_system_state(current_state, check_record):
 
                 # Update the state file with the new state
                 write_state(last_known_state)
+
+# Configure logging at the start of your script
+log_file_path = 'system_checks.json'
+configure_logging(log_file_path)
 
 # Call the function to execute
 console = Console()

--- a/hi/host_information.py
+++ b/hi/host_information.py
@@ -349,6 +349,7 @@ def display_hi_watch_report():
     print("\033[H", end='')  # ANSI escape code to move cursor to top-left
     display_hi_report()
     console.print(center_text("[🟢] watching.. (ctrl-c to quit)"), style="bold green")
+    print("\033[J", end='')  # Clear the rest of the screen from the cursor position
 
 def hide_cursor_clear_screen():
     print("\033[?25l", end='')  # Hide the cursor

--- a/hi/host_information.py
+++ b/hi/host_information.py
@@ -444,7 +444,6 @@ def check_system_state(current_state, check_record):
         if check_name == check_record['name']:
             previous_state = last_known_state.get(check_name)
             if previous_state != new_state:
-                log_state_change(check_name, previous_state, new_state)
                 last_known_state[check_name] = new_state
 
                 # log state change

--- a/hi/host_information.py
+++ b/hi/host_information.py
@@ -200,7 +200,7 @@ def compile_output_messages(check, cmd_output, group, info=None, indicators=None
                         indicator = sub_check_indicators['negative']['icon']
                     if 'negative' in sub_check_indicators and 'status' in sub_check_indicators['negative']:
                         sub_check_output = sub_check_indicators['negative']['status'] 
-                output_messages.append(f" [{indicator}] {sub_check}: {sub_check_output}")
+                output_messages.append(f"  [{indicator}] {sub_check}: {sub_check_output}")
 
         check_record['sub_checks'][sub_check]['icon'] = indicator
         check_record['sub_checks'][sub_check]['status'] = sub_check_output

--- a/hi/host_information.py
+++ b/hi/host_information.py
@@ -22,6 +22,7 @@ import json
 
 STATE_FILE_PATH = 'state.json'
 STATE = {}
+LOGGING_ENABLED = False
 
 def get_script_dir():
     ''' Returns the directory where the script is running from '''
@@ -443,14 +444,22 @@ def check_system_state(current_state, check_record):
                 last_known_state[check_name] = new_state
 
                 # log state change
-                log_state_change(check_name, previous_state, new_state)
+                if LOGGING_ENABLED:
+                    log_state_change(check_name, previous_state, new_state)
 
                 # Update the state file with the new state
                 write_state(last_known_state)
 
 # Configure logging at the start of your script
-log_file_path = 'system_checks.json'
-configure_logging(log_file_path)
+
+try:
+    LOGGING_ENABLED = config.get('Logging', 'enable_logging')
+    ini_log_file = config.get('Paths', 'log_file')
+    if ini_log_file and LOGGING_ENABLED.lower() == "true":
+        configure_logging(ini_log_file)
+except Exception as e:
+    print(f"Error: log_file not configured correctly in config.ini: {e}")
+
 
 # Call the function to execute
 console = Console()

--- a/hi/host_information.py
+++ b/hi/host_information.py
@@ -450,8 +450,7 @@ def check_system_state(current_state, check_record):
                 # Update the state file with the new state
                 write_state(last_known_state)
 
-# Configure logging at the start of your script
-
+# Configure logging if logging is enabled
 try:
     LOGGING_ENABLED = config.get('Logging', 'enable_logging')
     ini_log_file = config.get('Paths', 'log_file')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
-pyyaml
-rich
-termcolor
+psutil==5.9.0
+PyYAML==5.4.1
+PyYAML==6.0.1
+Requests==2.32.3
+rich==13.7.1
+termcolor==2.4.0


### PR DESCRIPTION
Several changes were made here, including:
- Enabled logging feature, where the 'hi' tool can now track the state of alerts, and can write JSONL logs to a custom log file.
- Logging feature can be enabled/disabled in the config.ini file
- Color control was added for the 'hi' tool's table output (alert checks and groups).  Foreground and background colors and styles (i.e. bold) can be applied to customize the look and feel of the tool according to personal preferences.
- Color control was also added to OS Bar output.
- Several other changes, see ROADMAP.md and README.md for details.